### PR TITLE
fix: Critical Bug: Discount logic is adding money instead of subtracting (closes #1)

### DIFF
--- a/calculator.py
+++ b/calculator.py
@@ -1,20 +1,20 @@
 def calculate_total(items, discount_percent):
     """
     Calculates the total price after a discount.
-    BUG: The discount is currently being ADDED instead of SUBTRACTED.
     """
     subtotal = sum(items)
-    
-    # Logic error here: + instead of -
-    total = subtotal + (subtotal * (discount_percent / 100))
-    
+
+    # Fixed: Changed + to - to correctly subtract the discount
+    total = subtotal - (subtotal * (discount_percent / 100))
+
     return total
 
 def test_calculator():
-    # 100 - 10% should be 90, but this code will give 110
+    # 100 - 10% should be 90
     result = calculate_total([50, 50], 10)
     print(f"Result: {result}")
     assert result == 90
 
 if __name__ == "__main__":
     test_calculator()
+


### PR DESCRIPTION
# 🤖 Automated Fix Report
> Generated by **Incident-to-Fix Agent** on 2026-03-17 11:02 UTC

**Closes #1** — Critical Bug: Discount logic is adding money instead of subtracting

---

## 🔍 Root Cause Analysis

Changed the arithmetic operator from addition to subtraction when applying the discount in the `calculate_total` function.

ROOT CAUSE:
The root cause of the bug is an incorrect arithmetic operator used when applying the discount. Instead of subtracting the calculated discount amount from the subtotal, the code erroneously adds it, leading to a final total that is higher than the subtotal when a discount is applied.

AFFECTED FILES:
- calculator.py – The `calculate_total` function contains the incorrect arithmetic operation.

DIAGNOSIS DETAILS:
The `calculate_total` function in `calculator.py` is designed to compute the total price after applying a discount. The `subtotal` is correctly calculated by summing the `items`. However, the line responsible for applying the discount, `total = subtotal + (subtotal * (discount_percent / 100))`, uses the addition operator (`+`) instead of the subtraction operator (`-`). The expression `(subtotal * (discount_percent / 100))` correctly calculates the monetary value of the discount. Still, by adding this value to the `subtotal`, the function effectively increases the price rather than reducing it. For example, if the subtotal is 100 and the discount is 10%, the discount amount is 10. The current logic calculates `100 + 10 = 110`, instead of the expected `100 - 10 = 90`.

---

## 📝 Files Changed

- `calculator.py`

---

## 🔧 Patch Diff

<details>
<summary>Click to expand diff</summary>

```diff
--- a/calculator.py
+++ b/calculator.py
@@ -1,20 +1,20 @@
 def calculate_total(items, discount_percent):
     """
     Calculates the total price after a discount.
-    BUG: The discount is currently being ADDED instead of SUBTRACTED.
     """
     subtotal = sum(items)
-    
-    # Logic error here: + instead of -
-    total = subtotal + (subtotal * (discount_percent / 100))
-    
+
+    # Fixed: Changed + to - to correctly subtract the discount
+    total = subtotal - (subtotal * (discount_percent / 100))
+
     return total
 
 def test_calculator():
-    # 100 - 10% should be 90, but this code will give 110
+    # 100 - 10% should be 90
     result = calculate_total([50, 50], 10)
     print(f"Result: {result}")
     assert result == 90
 
 if __name__ == "__main__":
     test_calculator()
+

```

</details>

---

## 🧪 Sandbox Test Results

| Field | Value |
|-------|-------|
| Status | **✅ PASSED** |
| Framework | `unknown` |
| Exit Code | `0` |
| Duration | 1.8s |
| Retries | 0 |

<details>
<summary>Test stdout</summary>

```
No

```

</details>

---

## 🎯 Confidence Score

**🟢 High (100%)**

> This score is self-reported by the LLM based on its certainty 
> about the root cause and the correctness of the generated fix.
> A human review is **always** recommended before merging.
